### PR TITLE
update bower "main" property to use correct filename

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "angular-phonegap-barcodeScanner",
   "version": "0.1.0",
   "description": "An anglar.js wrapper around window.plugins.barcodeScanner for Phonegap/Cordova plugin",
-  "main": "dist/barcodeScanner.js",
+  "main": "dist/angularjs-barcodeScanner.min.js",
   "dependencies": {
     "angularjs": "*"
   },


### PR DESCRIPTION
An alternative would be to use the simpler `barcodeScanner.js` name and/or unminified version for the "main" property.  I personally would rather point to the unminified version during development and let my grunt build process take care of minification.
